### PR TITLE
 Ui: the FAQ section has some misalignments #178 

### DIFF
--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -28,7 +28,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline underline-offset-2 [&[data-state=open]>svg]:rotate-180",
+        "flex flex-1 items-center justify-between text-start py-4 text-sm font-medium transition-all hover:underline underline-offset-2 [&[data-state=open]>svg]:rotate-180",
         className
       )}
       {...props}


### PR DESCRIPTION
 Ui: the FAQ section has some misalignments #178 

Closes: #178 

Before:
![380580549-43884e26-ace0-4e5b-8a33-e87a224d91c0](https://github.com/user-attachments/assets/d636a327-1be9-47f9-95a0-e7efff67ea71)

After:
![Screenshot 2024-10-28 160452](https://github.com/user-attachments/assets/489061f0-f255-4f4e-bfd3-804ff0265aa9)
Mobile simulation:
![Screenshot 2024-10-28 160826](https://github.com/user-attachments/assets/9c6bda49-31a5-4494-8ed7-75601629fef5)
Preserving UI and larger screen:
![Screenshot 2024-10-28 161031](https://github.com/user-attachments/assets/147f6f39-bcb7-44d0-95a7-7ffd9c4cbd40)
